### PR TITLE
API-4182: First Job to Manage Deleting Unused Applications

### DIFF
--- a/app/uk/gov/hmrc/apiplatformmicroservice/config/Scheduler.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/config/Scheduler.scala
@@ -20,7 +20,7 @@ import com.google.inject.AbstractModule
 import javax.inject.{Inject, Singleton}
 import play.api.Application
 import play.api.inject.ApplicationLifecycle
-import uk.gov.hmrc.apiplatformmicroservice.scheduled.{DeleteUnregisteredDevelopersJob, DeleteUnregisteredDevelopersJobConfig, DeleteUnverifiedDevelopersJob, DeleteUnverifiedDevelopersJobConfig}
+import uk.gov.hmrc.apiplatformmicroservice.scheduled.{DeleteUnregisteredDevelopersJob, DeleteUnregisteredDevelopersJobConfig, DeleteUnverifiedDevelopersJob, DeleteUnverifiedDevelopersJobConfig, UpdateUnusedApplicationRecordsJob, UpdateUnusedProductionApplicationRecordJob, UpdateUnusedSandboxApplicationRecordJob}
 import uk.gov.hmrc.play.scheduling.{RunningOfScheduledJobs, ScheduledJob}
 
 import scala.concurrent.ExecutionContext
@@ -36,6 +36,8 @@ class Scheduler @Inject()(deleteUnverifiedDevelopersJobConfig: DeleteUnverifiedD
                           deleteUnverifiedDevelopersJob: DeleteUnverifiedDevelopersJob,
                           deleteUnregisteredDevelopersJobConfig: DeleteUnregisteredDevelopersJobConfig,
                           deleteUnregisteredDevelopersJob: DeleteUnregisteredDevelopersJob,
+                          updateUnusedSandboxApplicationRecordsJob: UpdateUnusedSandboxApplicationRecordJob,
+                          updateUnusedProductionApplicationRecordJob: UpdateUnusedProductionApplicationRecordJob,
                           override val applicationLifecycle: ApplicationLifecycle,
                           override val application: Application)
                          (implicit val ec: ExecutionContext) extends RunningOfScheduledJobs {
@@ -51,5 +53,9 @@ class Scheduler @Inject()(deleteUnverifiedDevelopersJobConfig: DeleteUnverifiedD
     Seq.empty
   }
 
-  override lazy val scheduledJobs: Seq[ScheduledJob] = deleteUnverifiedDevsJob ++ deleteUnregisteredDevsJob
+  lazy val unusedApplicationJobs: Seq[ScheduledJob] =
+    Seq(updateUnusedSandboxApplicationRecordsJob, updateUnusedProductionApplicationRecordJob)
+      .filter(_.isEnabled)
+
+  override lazy val scheduledJobs: Seq[ScheduledJob] = deleteUnverifiedDevsJob ++ deleteUnregisteredDevsJob ++ unusedApplicationJobs
 }

--- a/app/uk/gov/hmrc/apiplatformmicroservice/connectors/ThirdPartyApplicationConnector.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/connectors/ThirdPartyApplicationConnector.scala
@@ -53,12 +53,14 @@ abstract class ThirdPartyApplicationConnector(implicit val ec: ExecutionContext)
       .map(_.status)
   }
 
-  def applicationsLastUsedBefore(lastUseDate: DateTime)(implicit hc: HeaderCarrier): Future[List[(UUID, DateTime)]] = {
-    val dateFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
+  def applicationsLastUsedBefore(lastUseDate: DateTime): Future[List[ApplicationUsageDetails]] = {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
     http.GET[PaginatedApplicationLastUseResponse](
       url = s"$serviceBaseUrl/application",
       queryParams = Seq("lastUseBefore" -> urlEncode(ISODateFormatter.withZoneUTC().print(lastUseDate))))
       .map(page => toDomain(page.applications))
+  }
 
   private def urlEncode(str: String, encoding: String = "UTF-8"): String = encode(str, encoding)
 }

--- a/app/uk/gov/hmrc/apiplatformmicroservice/connectors/ThirdPartyApplicationConnector.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/connectors/ThirdPartyApplicationConnector.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.apiplatformmicroservice.connectors
 import java.net.URLEncoder.encode
 import java.util.UUID
 
+import com.google.inject.AbstractModule
+import com.google.inject.name.Names
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
@@ -31,6 +33,13 @@ import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
 import scala.concurrent.{ExecutionContext, Future}
+
+class ThirdPartyApplicationConnectorModule extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[ThirdPartyApplicationConnector]).annotatedWith(Names.named("tpa-production")).to(classOf[ProductionThirdPartyApplicationConnector])
+    bind(classOf[ThirdPartyApplicationConnector]).annotatedWith(Names.named("tpa-sandbox")).to(classOf[SandboxThirdPartyApplicationConnector])
+  }
+}
 
 abstract class ThirdPartyApplicationConnector(implicit val ec: ExecutionContext) {
   val ISODateFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()

--- a/app/uk/gov/hmrc/apiplatformmicroservice/models/UnusedApplication.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/models/UnusedApplication.scala
@@ -19,10 +19,10 @@ package uk.gov.hmrc.apiplatformmicroservice.models
 import java.util.UUID
 
 import org.joda.time.DateTime
-import play.api.libs.json.{Format, JsError, JsPath, JsResult, JsString, JsSuccess, JsValue, Json, Reads, Writes}
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
 import uk.gov.hmrc.apiplatformmicroservice.models.Environment.Environment
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 case class ApplicationUsageDetails(applicationId: UUID, creationDate: DateTime, lastAccessDate: Option[DateTime])
 
@@ -37,6 +37,7 @@ object MongoFormat {
   implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
 
   implicit def environmentWrites: Writes[Environment.Value] = (v: Environment.Value) => JsString(v.toString)
+  implicit val environmentFormat: Format[Environment.Value] = Format(environmentReads(), environmentWrites)
 
   val unusedApplicationReads: Reads[UnusedApplication] = (
     (JsPath \ "applicationId").read[UUID] and
@@ -58,6 +59,6 @@ object MongoFormat {
   }
 
   implicit val unusedApplicationFormat = Format(unusedApplicationReads, Json.writes[UnusedApplication])
-  implicit val environmentFormat: Format[Environment.Value] = Format(environmentReads(), environmentWrites)
+
 
 }

--- a/app/uk/gov/hmrc/apiplatformmicroservice/models/UnusedApplication.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/models/UnusedApplication.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.models
+
+import java.util.UUID
+
+import org.joda.time.DateTime
+import play.api.libs.json.{Format, JsPath, Json, Reads}
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import play.api.libs.functional.syntax._
+
+case class ApplicationUsageDetails(applicationId: UUID, creationDate: DateTime, lastAccessDate: Option[DateTime])
+
+case class UnusedApplication(applicationId: UUID, lastInteractionDate: DateTime)
+
+object MongoFormat {
+  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
+
+  val unusedApplicationReads: Reads[UnusedApplication] = (
+    (JsPath \ "applicationId").read[UUID] and
+      (JsPath \ "lastInteractionDate").read[DateTime]
+    )(UnusedApplication.apply _)
+
+  implicit val unusedApplicationFormat = {
+    Format(unusedApplicationReads, Json.writes[UnusedApplication])
+  }
+}

--- a/app/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepository.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepository.scala
@@ -16,17 +16,20 @@
 
 package uk.gov.hmrc.apiplatformmicroservice.repository
 
+import java.util.UUID
+
 import akka.stream.Materializer
 import javax.inject.{Inject, Singleton}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.indexes.Index
 import reactivemongo.api.indexes.IndexType.Ascending
 import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.apiplatformmicroservice.models.Environment.Environment
 import uk.gov.hmrc.apiplatformmicroservice.models.{MongoFormat, UnusedApplication}
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class UnusedApplicationsRepository @Inject()(mongo: ReactiveMongoComponent)(implicit val mat: Materializer, val ec: ExecutionContext)
@@ -34,9 +37,13 @@ class UnusedApplicationsRepository @Inject()(mongo: ReactiveMongoComponent)(impl
     MongoFormat.unusedApplicationFormat, ReactiveMongoFormats.objectIdFormats) {
 
   override def indexes = List(
-    Index(key = List("applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
-    Index(key = List("environment" -> Ascending), name = Some("environmentIndex"), unique = false, background = true),
+    Index(key = List("environment" -> Ascending, "applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
     Index(key = List("lastInteractionDate" -> Ascending), name = Some("lastInteractionDateIndex"), unique = false, background = true)
   )
 
+  def applicationsByEnvironment(environment: Environment): Future[List[UnusedApplication]] = find("environment" -> environment)
+
+  def deleteApplication(environment: Environment, applicationId: UUID): Future[Boolean] =
+    remove("environment" -> environment, "applicationId" -> applicationId)
+      .map(_.ok)
 }

--- a/app/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepository.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepository.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.repository
+
+import akka.stream.Materializer
+import javax.inject.{Inject, Singleton}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.indexes.Index
+import reactivemongo.api.indexes.IndexType.Ascending
+import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.apiplatformmicroservice.models.{MongoFormat, UnusedApplication}
+import uk.gov.hmrc.mongo.ReactiveRepository
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class UnusedApplicationsRepository @Inject()(mongo: ReactiveMongoComponent)(implicit val mat: Materializer, val ec: ExecutionContext)
+  extends ReactiveRepository[UnusedApplication, BSONObjectID]("unusedApplications", mongo.mongoConnector.db,
+    MongoFormat.unusedApplicationFormat, ReactiveMongoFormats.objectIdFormats) {
+
+  override def indexes = List(
+    Index(key = List("applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
+    Index(key = List("lastInteractionDate" -> Ascending), name = Some("lastInteractionDateIndex"), unique = false, background = true)
+  )
+
+}

--- a/app/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepository.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepository.scala
@@ -35,6 +35,7 @@ class UnusedApplicationsRepository @Inject()(mongo: ReactiveMongoComponent)(impl
 
   override def indexes = List(
     Index(key = List("applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
+    Index(key = List("environment" -> Ascending), name = Some("environmentIndex"), unique = false, background = true),
     Index(key = List("lastInteractionDate" -> Ascending), name = Some("lastInteractionDateIndex"), unique = false, background = true)
   )
 

--- a/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/TimedJob.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/TimedJob.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.scheduled
+
+import java.util.concurrent.TimeUnit
+
+import javax.inject.Inject
+import net.ceedubs.ficus.Ficus._
+import org.joda.time.{DateTime, DateTimeZone, Duration, LocalTime}
+import play.api.{Configuration, Logger, LoggerLike}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import uk.gov.hmrc.lock.{LockKeeper, LockRepository}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+abstract class TimedJob @Inject()(override val name: String,
+                                  configuration: Configuration,
+                                  mongo: ReactiveMongoComponent,
+                                  val logger: LoggerLike = Logger) extends ScheduledMongoJob with TimedJobConfigReaders {
+
+  override val lockKeeper: LockKeeper = mongoLockKeeper(mongo)
+
+  val jobConfig: TimedJobConfig = configuration.underlying.as[TimedJobConfig](name)
+
+  def isEnabled: Boolean = jobConfig.enabled
+
+  override def initialDelay: FiniteDuration = jobConfig.startTime match {
+    case Some(startTime) => calculateInitialDelay(startTime.startTime)
+    case _ => FiniteDuration(0, TimeUnit.MILLISECONDS)
+  }
+
+  override def interval: FiniteDuration = jobConfig.executionInterval.interval
+
+  def calculateInitialDelay(timeOfFirstRun: LocalTime): FiniteDuration = {
+    val currentDateTime = DateTime.now(DateTimeZone.UTC)
+    val timeToday = timeOfFirstRun.toDateTimeToday(DateTimeZone.UTC)
+    val nextInstanceOfTime = if (timeToday.isBefore(currentDateTime)) timeToday.plusDays(1) else timeToday
+    val millisecondsToFirstRun = nextInstanceOfTime.getMillis - currentDateTime.getMillis
+
+    FiniteDuration(millisecondsToFirstRun, TimeUnit.MILLISECONDS)
+  }
+
+  def mongoLockKeeper(mongo: ReactiveMongoComponent): LockKeeper = new LockKeeper {
+    override def repo: LockRepository = new LockRepository()(mongo.mongoConnector.db)
+    override def lockId: String = s"$name-Lock"
+    override val forceLockReleaseAfter: Duration = Duration.standardHours(1)
+  }
+
+  override final def runJob(implicit ec: ExecutionContext): Future[RunningOfJobSuccessful] = {
+    logger.info(s"Starting scheduled job [$name].")
+    val result = functionToExecute()
+    logger.info(s"Scheduled job [$name] complete.")
+
+    result
+  }
+
+  def functionToExecute()(implicit executionContext: ExecutionContext): Future[RunningOfJobSuccessful]
+}
+
+class StartTime(val startTime: LocalTime) extends AnyVal
+class ExecutionInterval(val interval: FiniteDuration) extends AnyVal
+
+case class TimedJobConfig(startTime: Option[StartTime], executionInterval: ExecutionInterval, enabled: Boolean) {
+  override def toString = s"TimedJobConfig{startTime=${startTime.getOrElse("Not Specified")} interval=${executionInterval.interval} enabled=$enabled}"
+}

--- a/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/TimedJobConfigReaders.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/TimedJobConfigReaders.scala
@@ -43,25 +43,6 @@ trait TimedJobConfigReaders {
       TimedJobConfig(parsedStartTime, parsedExecutionInterval, parsedEnabled)
   }
 
-//  implicit def deleteUnusedApplicationsConfigReader: ValueReader[DeleteUnusedApplicationsConfig] = ValueReader.relative[DeleteUnusedApplicationsConfig] {
-//    config =>
-//      val cutoff = config.as[FiniteDuration]("deleteApplicationsIfUnusedFor")
-//      val dryRun = config.as[Option[Boolean]]("dryRun").getOrElse(true)
-//
-//      DeleteUnusedApplicationsConfig(cutoff, dryRun)
-//  }
-//
-//  implicit def applicationToBeDeletedNotificationsConfigReader: ValueReader[ApplicationToBeDeletedNotificationsConfig] =
-//    ValueReader.relative[ApplicationToBeDeletedNotificationsConfig] {
-//      config =>
-//        val notificationCutoff = config.as[FiniteDuration]("sendNotificationsInAdvance")
-//        val emailServiceURL = config.as[String]("emailServiceURL")
-//        val emailTemplateId = config.as[String]("emailTemplateId")
-//        val environmentName = config.as[String]("environmentName")
-//        val dryRun = config.as[Option[Boolean]]("dryRun").getOrElse(true)
-//
-//        ApplicationToBeDeletedNotificationsConfig(notificationCutoff, emailServiceURL, emailTemplateId, environmentName, dryRun)
-//    }
 }
 
 object TimedJobConfigReaders extends TimedJobConfigReaders

--- a/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/TimedJobConfigReaders.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/TimedJobConfigReaders.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.scheduled
+
+import com.typesafe.config.{Config, ConfigException}
+import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ValueReader
+import org.joda.time.LocalTime
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+trait TimedJobConfigReaders {
+
+  implicit def localTimeReader: ValueReader[LocalTime] = (config: Config, path: String) => {
+    (Try {
+      LocalTime.parse(config.getString(path))
+    } recover {
+      case ex => throw new ConfigException.BadValue(path, config.getString(path), ex)
+    }).get
+  }
+
+  implicit def timedJobConfigReader: ValueReader[TimedJobConfig] = ValueReader.relative[TimedJobConfig] {
+    config =>
+      val parsedStartTime: Option[StartTime] = config.as[Option[LocalTime]]("startTime").map(new StartTime(_))
+      val parsedExecutionInterval = new ExecutionInterval(config.as[FiniteDuration]("executionInterval"))
+      val parsedEnabled: Boolean = config.as[Option[Boolean]]("enabled").getOrElse(false)
+
+      TimedJobConfig(parsedStartTime, parsedExecutionInterval, parsedEnabled)
+  }
+
+//  implicit def deleteUnusedApplicationsConfigReader: ValueReader[DeleteUnusedApplicationsConfig] = ValueReader.relative[DeleteUnusedApplicationsConfig] {
+//    config =>
+//      val cutoff = config.as[FiniteDuration]("deleteApplicationsIfUnusedFor")
+//      val dryRun = config.as[Option[Boolean]]("dryRun").getOrElse(true)
+//
+//      DeleteUnusedApplicationsConfig(cutoff, dryRun)
+//  }
+//
+//  implicit def applicationToBeDeletedNotificationsConfigReader: ValueReader[ApplicationToBeDeletedNotificationsConfig] =
+//    ValueReader.relative[ApplicationToBeDeletedNotificationsConfig] {
+//      config =>
+//        val notificationCutoff = config.as[FiniteDuration]("sendNotificationsInAdvance")
+//        val emailServiceURL = config.as[String]("emailServiceURL")
+//        val emailTemplateId = config.as[String]("emailTemplateId")
+//        val environmentName = config.as[String]("environmentName")
+//        val dryRun = config.as[Option[Boolean]]("dryRun").getOrElse(true)
+//
+//        ApplicationToBeDeletedNotificationsConfig(notificationCutoff, emailServiceURL, emailTemplateId, environmentName, dryRun)
+//    }
+}
+
+object TimedJobConfigReaders extends TimedJobConfigReaders

--- a/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJob.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJob.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.apiplatformmicroservice.scheduled
 import java.util.UUID
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton, Named}
 import net.ceedubs.ficus.Ficus._
 import org.joda.time.DateTime
 import play.api.{Configuration, Logger}
@@ -30,11 +30,11 @@ import uk.gov.hmrc.apiplatformmicroservice.repository.UnusedApplicationsReposito
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class UpdateUnusedApplicationRecordsJob @Inject()(environment: Environment,
-                                                           thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
-                                                           unusedApplicationsRepository: UnusedApplicationsRepository,
-                                                           configuration: Configuration,
-                                                           mongo: ReactiveMongoComponent)
+abstract class UpdateUnusedApplicationRecordsJob (environment: Environment,
+                                                  thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
+                                                  unusedApplicationsRepository: UnusedApplicationsRepository,
+                                                  configuration: Configuration,
+                                                  mongo: ReactiveMongoComponent)
   extends TimedJob(s"UpdateUnusedApplicationsRecords-$environment", configuration, mongo) {
 
   val DeleteUnusedApplicationsAfter: FiniteDuration = configuration.underlying.as[FiniteDuration]("deleteUnusedApplicationsAfter")
@@ -83,13 +83,15 @@ abstract class UpdateUnusedApplicationRecordsJob @Inject()(environment: Environm
   }
 }
 
-class UpdateUnusedSandboxApplicationRecordJob @Inject()(thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
+@Singleton
+class UpdateUnusedSandboxApplicationRecordJob @Inject()(@Named("tpa-sandbox") thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
                                                         unusedApplicationsRepository: UnusedApplicationsRepository,
                                                         configuration: Configuration,
                                                         mongo: ReactiveMongoComponent)
   extends UpdateUnusedApplicationRecordsJob(Environment.SANDBOX, thirdPartyApplicationConnector, unusedApplicationsRepository, configuration, mongo)
 
-class UpdateUnusedProductionApplicationRecordJob @Inject()(thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
+@Singleton
+class UpdateUnusedProductionApplicationRecordJob @Inject()(@Named("tpa-production") thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
                                                         unusedApplicationsRepository: UnusedApplicationsRepository,
                                                         configuration: Configuration,
                                                         mongo: ReactiveMongoComponent)

--- a/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJob.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJob.scala
@@ -62,7 +62,10 @@ abstract class UpdateUnusedApplicationRecordsJob @Inject()(environment: Environm
     }
 
     def removeApplications(applicationsToRemove: Set[UUID]) =
-      Future.sequence(applicationsToRemove.map(unusedApplicationsRepository.deleteApplication(environment, _)))
+      Future.sequence(applicationsToRemove.map { applicationId =>
+        Logger.info(s"[UpdateUnusedApplicationRecordsJob] Application [$applicationId] in $environment environment has been used since last update - removing from list of unused applications to delete")
+        unusedApplicationsRepository.deleteApplication(environment, applicationId)
+      })
 
     for {
       knownApplications <- unusedApplicationsRepository.applicationsByEnvironment(environment)

--- a/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJob.scala
+++ b/app/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJob.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.scheduled
+import java.util.UUID
+
+import javax.inject.Inject
+import net.ceedubs.ficus.Ficus._
+import org.joda.time.DateTime
+import play.api.Configuration
+import play.modules.reactivemongo.ReactiveMongoComponent
+import uk.gov.hmrc.apiplatformmicroservice.connectors.ThirdPartyApplicationConnector
+import uk.gov.hmrc.apiplatformmicroservice.models.Environment.Environment
+import uk.gov.hmrc.apiplatformmicroservice.models.{ApplicationUsageDetails, Environment, UnusedApplication}
+import uk.gov.hmrc.apiplatformmicroservice.repository.UnusedApplicationsRepository
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+abstract class UpdateUnusedApplicationRecordsJob @Inject()(environment: Environment,
+                                                           thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
+                                                           unusedApplicationsRepository: UnusedApplicationsRepository,
+                                                           configuration: Configuration,
+                                                           mongo: ReactiveMongoComponent)
+  extends TimedJob(s"UpdateUnusedApplicationsRecords-$environment", configuration, mongo) {
+
+  val DeleteUnusedApplicationsAfter: FiniteDuration = configuration.underlying.as[FiniteDuration]("deleteUnusedApplicationsAfter")
+  val NotifyDeletionPendingInAdvance: FiniteDuration = configuration.underlying.as[FiniteDuration]("notifyDeletionPendingInAdvance")
+
+  def notificationCutoffDate(): DateTime =
+    DateTime.now
+      .minus(DeleteUnusedApplicationsAfter.toMillis)
+      .plus(NotifyDeletionPendingInAdvance.toMillis)
+
+  override def functionToExecute()(implicit executionContext: ExecutionContext): Future[RunningOfJobSuccessful] = {
+    def unknownApplications(knownApplications: List[UnusedApplication], currentUnusedApplications: List[ApplicationUsageDetails]): Seq[UnusedApplication] = {
+      val knownApplicationIds = knownApplications.map(_.applicationId)
+      currentUnusedApplications
+        .filterNot(app => knownApplicationIds.contains(app.applicationId))
+        .map(app => UnusedApplication(app.applicationId, environment, app.lastAccessDate.getOrElse(app.creationDate)))
+    }
+
+    def noLongerUnusedApplications(knownApplications: List[UnusedApplication], currentUnusedApplications: List[ApplicationUsageDetails]): Set[UUID] = {
+      val currentUnusedApplicationIds = currentUnusedApplications.map(_.applicationId)
+      knownApplications
+        .filterNot(app => currentUnusedApplicationIds.contains(app.applicationId))
+        .map(_.applicationId)
+        .toSet
+    }
+
+    def removeApplications(applicationsToRemove: Set[UUID]) =
+      Future.sequence(applicationsToRemove.map(unusedApplicationsRepository.deleteApplication(environment, _)))
+
+    for {
+      knownApplications <- unusedApplicationsRepository.applicationsByEnvironment(environment)
+      currentUnusedApplications <- thirdPartyApplicationConnector.applicationsLastUsedBefore(notificationCutoffDate())
+      _ <- unusedApplicationsRepository.bulkInsert(unknownApplications(knownApplications, currentUnusedApplications))
+      _ <- removeApplications(noLongerUnusedApplications(knownApplications, currentUnusedApplications))
+    } yield RunningOfJobSuccessful
+  }
+}
+
+class UpdateUnusedSandboxApplicationRecordJob @Inject()(thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
+                                                        unusedApplicationsRepository: UnusedApplicationsRepository,
+                                                        configuration: Configuration,
+                                                        mongo: ReactiveMongoComponent)
+  extends UpdateUnusedApplicationRecordsJob(Environment.SANDBOX, thirdPartyApplicationConnector, unusedApplicationsRepository, configuration, mongo)
+
+class UpdateUnusedProductionApplicationRecordJob @Inject()(thirdPartyApplicationConnector: ThirdPartyApplicationConnector,
+                                                        unusedApplicationsRepository: UnusedApplicationsRepository,
+                                                        configuration: Configuration,
+                                                        mongo: ReactiveMongoComponent)
+  extends UpdateUnusedApplicationRecordsJob(Environment.PRODUCTION, thirdPartyApplicationConnector, unusedApplicationsRepository, configuration, mongo)

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import play.core.PlayVersion
 import sbt.Tests.{Group, SubProcess}
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 import uk.gov.hmrc.SbtAutoBuildPlugin
@@ -26,7 +27,9 @@ def testDeps(scope: String) = Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % scope,
   "org.mockito" % "mockito-core" % "3.1.0" % scope,
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % scope,
-  "uk.gov.hmrc" %% "reactivemongo-test" % "4.16.0-play-26" % scope
+  "org.mockito" %% "mockito-scala-scalatest" % "1.7.1" % scope,
+  "uk.gov.hmrc" %% "reactivemongo-test" % "4.16.0-play-26" % scope,
+  "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
 )
 
 lazy val root = (project in file("."))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,7 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
 # Additional play modules can be added here
 play.modules.enabled += "uk.gov.hmrc.apiplatformmicroservice.config.ConfigurationModule"
 play.modules.enabled += "uk.gov.hmrc.apiplatformmicroservice.config.SchedulerModule"
+play.modules.enabled += "uk.gov.hmrc.apiplatformmicroservice.connectors.ThirdPartyApplicationConnectorModule"
 
 # Session Timeout
 # ~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -156,8 +156,20 @@ metrics {
 }
 
 # Microservice specific config
-deleteUnusedApplicationsAfter = 12m
-notifyDeletionPendingInAdvance = 1m
+deleteUnusedApplicationsAfter = 365d
+notifyDeletionPendingInAdvance = 30d
+
+UpdateUnusedApplicationsRecords-SANDBOX {
+  startTime = "00:30"
+  executionInterval = 1d
+  enabled = false
+}
+
+UpdateUnusedApplicationsRecords-PRODUCTION {
+  startTime = "01:00"
+  executionInterval = 1d
+  enabled = false
+}
 
 auditing {
   enabled = true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -156,6 +156,8 @@ metrics {
 }
 
 # Microservice specific config
+deleteUnusedApplicationsAfter = 12m
+notifyDeletionPendingInAdvance = 1m
 
 auditing {
   enabled = true

--- a/test/uk/gov/hmrc/apiplatformmicroservice/connectors/ThirdPartyApplicationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/connectors/ThirdPartyApplicationConnectorSpec.scala
@@ -27,7 +27,7 @@ import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.OK
-import uk.gov.hmrc.apiplatformmicroservice.connectors.ThirdPartyApplicationConnector.{ApplicationLastUseDate, ApplicationResponse}
+import uk.gov.hmrc.apiplatformmicroservice.connectors.ThirdPartyApplicationConnector.{ApplicationLastUseDate, ApplicationResponse, PaginatedApplicationLastUseResponse}
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import uk.gov.hmrc.play.test.UnitSpec
@@ -123,6 +123,9 @@ class ThirdPartyApplicationConnectorSpec extends UnitSpec with ScalaFutures with
   }
 
   "applicationsLastUsedBefore" should {
+    def paginatedResponse(lastUseDates: List[ApplicationLastUseDate]) =
+      PaginatedApplicationLastUseResponse(lastUseDates, 1, 100, lastUseDates.size, lastUseDates.size)
+
     val dateFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
 
     "return applicationId and lastUseDate as Tuples" in new Setup {
@@ -131,8 +134,10 @@ class ThirdPartyApplicationConnectorSpec extends UnitSpec with ScalaFutures with
       val oldApplication1 = ApplicationLastUseDate(UUID.randomUUID(), DateTime.now.minusMonths(13))
       val oldApplication2 = ApplicationLastUseDate(UUID.randomUUID(), DateTime.now.minusMonths(14))
 
-      when(mockHttpClient.GET[Seq[ApplicationLastUseDate]](meq( s"$baseUrl/application"), meq(Seq("lastUseBefore" -> encodedDateString)))(any(), any(), any()))
-        .thenReturn(successful(Seq(oldApplication1, oldApplication2)))
+      when(mockHttpClient.GET[PaginatedApplicationLastUseResponse](
+        meq( s"$baseUrl/application"),
+        meq(Seq("lastUseBefore" -> encodedDateString)))(any(), any(), any()))
+        .thenReturn(successful(paginatedResponse(List(oldApplication1, oldApplication2))))
 
       val results = await(connector.applicationsLastUsedBefore(lastUseDate))
 
@@ -144,8 +149,10 @@ class ThirdPartyApplicationConnectorSpec extends UnitSpec with ScalaFutures with
       val lastUseDate = DateTime.now.minusMonths(12)
       val encodedDateString: String = URLEncoder.encode(dateFormatter.withZoneUTC().print(lastUseDate), StandardCharsets.UTF_8.toString)
 
-      when(mockHttpClient.GET[Seq[ApplicationLastUseDate]](meq( s"$baseUrl/application"), meq(Seq("lastUseBefore" -> encodedDateString)))(any(), any(), any()))
-        .thenReturn(successful(Seq.empty))
+      when(mockHttpClient.GET[PaginatedApplicationLastUseResponse](
+        meq( s"$baseUrl/application"),
+        meq(Seq("lastUseBefore" -> encodedDateString)))(any(), any(), any()))
+        .thenReturn(successful(paginatedResponse(List.empty)))
 
       val results = await(connector.applicationsLastUsedBefore(lastUseDate))
 

--- a/test/uk/gov/hmrc/apiplatformmicroservice/repository/IndexVerification.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/repository/IndexVerification.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.repository
+
+import org.scalatest.concurrent.Eventually
+import reactivemongo.api.indexes.Index
+import uk.gov.hmrc.apiplatformmicroservice.util.AsyncHmrcSpec
+import uk.gov.hmrc.mongo.ReactiveRepository
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+trait IndexVerification extends AsyncHmrcSpec with Eventually {
+  def toCompare(index: Index) = Tuple5(index.key, index.name, index.unique, index.background, index.sparse)
+
+  def verifyIndexesVersionAgnostic[A, ID](repository: ReactiveRepository[A, ID], indexes: Set[Index])(implicit ec: ExecutionContext) = {
+    eventually(timeout(10.seconds), interval(1000.milliseconds)) {
+      val actualIndexes = await(repository.collection.indexesManager.list()).toSet
+      actualIndexes.map(toCompare) should contain allElementsOf (indexes.map(toCompare))
+    }
+  }
+
+  def verifyIndexDoesNotExist[A, ID](repository: ReactiveRepository[A, ID], indexName: String)(implicit ec: ExecutionContext) = {
+    eventually(timeout(10.seconds), interval(1000.milliseconds)) {
+      val actualIndexNames = await(repository.collection.indexesManager.list()).map(i => i.name).toSet
+      actualIndexNames should not contain Some(indexName)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepositorySpec.scala
@@ -54,6 +54,7 @@ class UnusedApplicationsRepositorySpec extends AsyncHmrcSpec
 
       val expectedIndexes = Set(
         Index(key = Seq("applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
+        Index(key = Seq("environment" -> Ascending), name = Some("environmentIndex"), unique = false, background = true),
         Index(key = Seq("lastInteractionDate" -> Ascending), name = Some("lastInteractionDateIndex"), unique = false, background = true)
       )
 

--- a/test/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepositorySpec.scala
@@ -16,14 +16,19 @@
 
 package uk.gov.hmrc.apiplatformmicroservice.repository
 
+import java.util.UUID
+
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
+import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.indexes.Index
 import reactivemongo.api.indexes.IndexType.Ascending
+import uk.gov.hmrc.apiplatformmicroservice.models.{Environment, UnusedApplication}
 import uk.gov.hmrc.apiplatformmicroservice.util.AsyncHmrcSpec
 import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class UnusedApplicationsRepositorySpec extends AsyncHmrcSpec
@@ -49,16 +54,98 @@ class UnusedApplicationsRepositorySpec extends AsyncHmrcSpec
     await(unusedApplicationRepository.drop)
   }
 
+  trait Setup {
+    def sandboxApplication(applicationId: UUID) = UnusedApplication(applicationId, Environment.SANDBOX, DateTime.now)
+    def productionApplication(applicationId: UUID) = UnusedApplication(applicationId, Environment.PRODUCTION, DateTime.now)
+  }
+
   "The 'unusedApplications' collection" should {
     "have all the current indexes" in {
 
       val expectedIndexes = Set(
-        Index(key = Seq("applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
-        Index(key = Seq("environment" -> Ascending), name = Some("environmentIndex"), unique = false, background = true),
+        Index(key = Seq("environment" -> Ascending, "applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
         Index(key = Seq("lastInteractionDate" -> Ascending), name = Some("lastInteractionDateIndex"), unique = false, background = true)
       )
 
       verifyIndexesVersionAgnostic(unusedApplicationRepository, expectedIndexes)
+    }
+  }
+
+  "applicationsByEnvironment" should {
+
+
+    "correctly retrieve SANDBOX applications" in new Setup {
+      val sandboxApplicationId = UUID.randomUUID
+
+      await(unusedApplicationRepository
+        .bulkInsert(
+          Seq(
+            sandboxApplication(sandboxApplicationId),
+            productionApplication(UUID.randomUUID()),
+            productionApplication(UUID.randomUUID()))))
+
+      val results = await(unusedApplicationRepository.applicationsByEnvironment(Environment.SANDBOX))
+
+      results.size should be (1)
+      results.head.applicationId should be (sandboxApplicationId)
+    }
+
+    "correctly retrieve PRODUCTION applications" in new Setup {
+      val productionApplication1Id = UUID.randomUUID
+      val productionApplication2Id = UUID.randomUUID
+
+      await(unusedApplicationRepository
+        .bulkInsert(
+          Seq(
+            sandboxApplication(UUID.randomUUID()),
+            productionApplication(productionApplication1Id),
+            productionApplication(productionApplication2Id))))
+
+      val results = await(unusedApplicationRepository.applicationsByEnvironment(Environment.PRODUCTION))
+
+      results.size should be (2)
+      val returnedApplicationIds = results.map(_.applicationId)
+      returnedApplicationIds should contain (productionApplication1Id)
+      returnedApplicationIds should contain (productionApplication2Id)
+    }
+  }
+
+  "deleteApplication" should {
+    "correctly remove a SANDBOX application" in new Setup {
+      val sandboxApplicationId = UUID.randomUUID
+
+      await(unusedApplicationRepository
+        .bulkInsert(
+          Seq(
+            sandboxApplication(sandboxApplicationId),
+            productionApplication(UUID.randomUUID()),
+            productionApplication(UUID.randomUUID()))))
+
+      val result = await(unusedApplicationRepository.deleteApplication(Environment.SANDBOX, sandboxApplicationId))
+
+      result should be (true)
+      await(unusedApplicationRepository.applicationsByEnvironment(Environment.SANDBOX)).size should be (0)
+    }
+
+    "correctly remove a PRODUCTION application" in new Setup {
+      val productionApplicationId = UUID.randomUUID
+
+      await(unusedApplicationRepository
+        .bulkInsert(
+          Seq(
+            sandboxApplication(UUID.randomUUID()),
+            productionApplication(productionApplicationId))))
+
+      val result = await(unusedApplicationRepository.deleteApplication(Environment.PRODUCTION, productionApplicationId))
+
+      result should be (true)
+      await(unusedApplicationRepository.applicationsByEnvironment(Environment.PRODUCTION)).size should be (0)
+    }
+
+    "return true if application id was not found in database" in {
+      val result = await(unusedApplicationRepository.deleteApplication(Environment.PRODUCTION, UUID.randomUUID()))
+
+      result should be (true)
     }
   }
 }

--- a/test/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/repository/UnusedApplicationsRepositorySpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.repository
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.indexes.Index
+import reactivemongo.api.indexes.IndexType.Ascending
+import uk.gov.hmrc.apiplatformmicroservice.util.AsyncHmrcSpec
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UnusedApplicationsRepositorySpec extends AsyncHmrcSpec
+  with MongoSpecSupport
+  with BeforeAndAfterEach with BeforeAndAfterAll
+  with IndexVerification {
+
+  implicit var s : ActorSystem = ActorSystem("test")
+  implicit var m : Materializer = ActorMaterializer()
+
+  private val reactiveMongoComponent = new ReactiveMongoComponent {
+    override def mongoConnector: MongoConnector = mongoConnectorForTest
+  }
+
+  private val unusedApplicationRepository = new UnusedApplicationsRepository(reactiveMongoComponent)
+
+  override def beforeEach() {
+    await(unusedApplicationRepository.drop)
+    await(unusedApplicationRepository.ensureIndexes)
+  }
+
+  override protected def afterAll() {
+    await(unusedApplicationRepository.drop)
+  }
+
+  "The 'unusedApplications' collection" should {
+    "have all the current indexes" in {
+
+      val expectedIndexes = Set(
+        Index(key = Seq("applicationId" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
+        Index(key = Seq("lastInteractionDate" -> Ascending), name = Some("lastInteractionDateIndex"), unique = false, background = true)
+      )
+
+      verifyIndexesVersionAgnostic(unusedApplicationRepository, expectedIndexes)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJobSpec.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/scheduled/UpdateUnusedApplicationRecordsJobSpec.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.scheduled
+
+import java.util.UUID
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.joda.time.DateTime
+import org.mockito.Mockito.{verifyNoInteractions, when}
+import org.mockito.{ArgumentCaptor, ArgumentMatchersSugar}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.Configuration
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.commands.MultiBulkWriteResult
+import uk.gov.hmrc.apiplatformmicroservice.connectors.{ProductionThirdPartyApplicationConnector, SandboxThirdPartyApplicationConnector}
+import uk.gov.hmrc.apiplatformmicroservice.models.Environment.Environment
+import uk.gov.hmrc.apiplatformmicroservice.models.{ApplicationUsageDetails, Environment, UnusedApplication}
+import uk.gov.hmrc.apiplatformmicroservice.repository.UnusedApplicationsRepository
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class UpdateUnusedApplicationRecordsJobSpec extends PlaySpec
+  with MockitoSugar with ArgumentMatchersSugar with MongoSpecSupport with FutureAwaits with DefaultAwaitTimeout {
+
+  trait Setup {
+    val environmentName = "Test Environment"
+
+    def jobConfiguration(): Config = {
+      ConfigFactory.parseString(
+        s"""
+           |deleteUnusedApplicationsAfter = 365d
+           |notifyDeletionPendingInAdvance = 30d
+           |
+           |UpdateUnusedApplicationsRecords-SANDBOX {
+           |  startTime = "00:30"
+           |  executionInterval = 1d
+           |  enabled = false
+           |}
+           |
+           |UpdateUnusedApplicationsRecords-PRODUCTION {
+           |  startTime = "01:00"
+           |  executionInterval = 1d
+           |  enabled = false
+           |}
+           |
+           |""".stripMargin)
+    }
+
+    val mockSandboxThirdPartyApplicationConnector: SandboxThirdPartyApplicationConnector = mock[SandboxThirdPartyApplicationConnector]
+    val mockProductionThirdPartyApplicationConnector: ProductionThirdPartyApplicationConnector = mock[ProductionThirdPartyApplicationConnector]
+    val mockUnusedApplicationsRepository: UnusedApplicationsRepository = mock[UnusedApplicationsRepository]
+
+    val reactiveMongoComponent: ReactiveMongoComponent = new ReactiveMongoComponent {
+      override def mongoConnector: MongoConnector = mongoConnectorForTest
+    }
+  }
+
+  trait SandboxJobSetup extends Setup {
+    val configuration = new Configuration(jobConfiguration())
+
+    val underTest = new UpdateUnusedSandboxApplicationRecordJob(
+      mockSandboxThirdPartyApplicationConnector,
+      mockUnusedApplicationsRepository,
+      configuration,
+      reactiveMongoComponent
+    )
+  }
+
+  trait ProductionJobSetup extends Setup {
+    val configuration = new Configuration(jobConfiguration())
+
+    val underTest = new UpdateUnusedProductionApplicationRecordJob(
+      mockProductionThirdPartyApplicationConnector,
+      mockUnusedApplicationsRepository,
+      configuration,
+      reactiveMongoComponent
+    )
+  }
+
+  "SANDBOX job" should {
+    "add all newly discovered unused applications to database" in new SandboxJobSetup {
+      val applicationWithLastUseDate: (ApplicationUsageDetails, UnusedApplication) =
+        applicationDetails(Environment.SANDBOX, DateTime.now.minusMonths(13), Some(DateTime.now.minusMonths(13)))
+      val applicationWithoutLastUseDate: (ApplicationUsageDetails, UnusedApplication) =
+        applicationDetails(Environment.SANDBOX, DateTime.now.minusMonths(13), None)
+
+      when(mockSandboxThirdPartyApplicationConnector.applicationsLastUsedBefore(*))
+        .thenReturn(Future.successful(List(applicationWithLastUseDate._1, applicationWithoutLastUseDate._1)))
+      when(mockUnusedApplicationsRepository.applicationsByEnvironment(Environment.SANDBOX)).thenReturn(Future(List.empty))
+
+      val insertCaptor: ArgumentCaptor[Seq[UnusedApplication]] = ArgumentCaptor.forClass(classOf[Seq[UnusedApplication]])
+      when(mockUnusedApplicationsRepository.bulkInsert(insertCaptor.capture())(*)).thenReturn(Future.successful(MultiBulkWriteResult.empty))
+
+      await(underTest.runJob)
+
+      val capturedInsertValue = insertCaptor.getValue
+      capturedInsertValue.size must be (2)
+      capturedInsertValue must contain (applicationWithLastUseDate._2)
+      capturedInsertValue must contain (applicationWithoutLastUseDate._2)
+
+      verifyNoInteractions(mockProductionThirdPartyApplicationConnector)
+    }
+  }
+
+  "PRODUCTION job" should {
+    "add all newly discovered unused applications to database" in new ProductionJobSetup {
+      val applicationWithLastUseDate: (ApplicationUsageDetails, UnusedApplication) =
+        applicationDetails(Environment.PRODUCTION, DateTime.now.minusMonths(13), Some(DateTime.now.minusMonths(13)))
+      val applicationWithoutLastUseDate: (ApplicationUsageDetails, UnusedApplication) =
+        applicationDetails(Environment.PRODUCTION, DateTime.now.minusMonths(13), None)
+
+      when(mockProductionThirdPartyApplicationConnector.applicationsLastUsedBefore(*))
+        .thenReturn(Future.successful(List(applicationWithLastUseDate._1, applicationWithoutLastUseDate._1)))
+      when(mockUnusedApplicationsRepository.applicationsByEnvironment(Environment.PRODUCTION)).thenReturn(Future(List.empty))
+
+      val insertCaptor: ArgumentCaptor[Seq[UnusedApplication]] = ArgumentCaptor.forClass(classOf[Seq[UnusedApplication]])
+      when(mockUnusedApplicationsRepository.bulkInsert(insertCaptor.capture())(*)).thenReturn(Future.successful(MultiBulkWriteResult.empty))
+
+      await(underTest.runJob)
+
+      val capturedInsertValue = insertCaptor.getValue
+      capturedInsertValue.size must be (2)
+      capturedInsertValue must contain (applicationWithLastUseDate._2)
+      capturedInsertValue must contain (applicationWithoutLastUseDate._2)
+
+      verifyNoInteractions(mockSandboxThirdPartyApplicationConnector)
+    }
+  }
+
+  def applicationDetails(environment: Environment, creationDate: DateTime, lastAccessDate: Option[DateTime]): (ApplicationUsageDetails, UnusedApplication) = {
+    val applicationId = UUID.randomUUID()
+
+    (ApplicationUsageDetails(applicationId, creationDate, lastAccessDate),
+      UnusedApplication(applicationId, environment, lastAccessDate.getOrElse(creationDate)))
+  }
+}

--- a/test/uk/gov/hmrc/apiplatformmicroservice/util/HmrcSpec.scala
+++ b/test/uk/gov/hmrc/apiplatformmicroservice/util/HmrcSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformmicroservice.util
+
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatestplus.play.WsScalaTestClient
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+
+abstract class HmrcSpec extends WordSpec with Matchers with OptionValues with WsScalaTestClient with MockitoSugar
+
+abstract class AsyncHmrcSpec
+  extends HmrcSpec with DefaultAwaitTimeout with FutureAwaits {
+}


### PR DESCRIPTION
As well as the usual code review stuff, can you guys give me a sanity check on what I'm doing here...

1. These jobs will read from the sandbox and production TPAs, finding the applications that haven't been used in a certain amount of time (configured by the 2 parameters in `application.conf`
2. Any it hasn't seen before, it stashes in a database
3. If there's one in the database that no longer comes back from TPA, it deletes it as that application has been used since the job last ran. Which means it's no longer on death row...
4. I'll build subsequent jobs to send the emails and do the actual deleting that will run entirely from the local database, rather than having to call out to TPA

Couple of things I'm not sure on:

1. Should I include the email sending as part of these jobs?
2. The retrieval from TPA of unused applications currently gets all of them in one go. That's probably fine going forward, but when we first start hitting apps not used there are going to be loads (several thousand in ET?) - should that function in the connector be recursive, using the paging feature of application search?